### PR TITLE
Fix tiles layer and zoom when GeoViewElement is not displayed at 0:0 position on its parent

### DIFF
--- a/src/GeoView/GeoViewInteractionsStrategy.class.st
+++ b/src/GeoView/GeoViewInteractionsStrategy.class.st
@@ -155,12 +155,12 @@ GeoViewInteractionsStrategy >> mouseWheelEvent: anEvent [
 
 	self allowMapScaling ifFalse:[ ^ self ].
 	element := anEvent currentTarget.
-	point := anEvent position.
+	point := element localPointFromGlobalPoint: anEvent position.
 	
 	mapProjection := element mapProjection ifNil:[ ^ self ].
 	graphicProjection := element displayToGraphicProjection ifNil:[ ^ self ].
 
-	geoPoint := element absoluteCoordinatesFromGlobalPoint: point.
+	geoPoint := element absoluteCoordinatesFromLocalPoint: point.
 	geoPointPx := graphicProjection projCartToPixel: (mapProjection projLatLonToCart: geoPoint).
 	geoCenterPx := graphicProjection projCartToPixel: (mapProjection projLatLonToCart: element geoCenter).
 	
@@ -178,11 +178,12 @@ GeoViewInteractionsStrategy >> mouseWheelEvent: anEvent [
 	self allowMapMoving ifFalse:[ ^ self ].
 	
 	"compute new position in pixel for the mouse position before zoom"
+	
 	geoPointPxNew := graphicProjection projCartToPixel: (mapProjection projLatLonToCart: geoPoint).
 	"add the previous diff in pixels to get new center in pixel"
 	newPointPx := geoPointPxNew + difPx.
 	"Compute new position in cartesian for new center"
-	geoPointFinal := element absoluteCoordinatesFromGlobalPoint: newPointPx.
+	geoPointFinal := element absoluteCoordinatesFromLocalPoint: newPointPx.
 	element geoCenter: geoPointFinal.
 ]
 

--- a/src/GeoView/GeoViewMapTilesLayer.class.st
+++ b/src/GeoView/GeoViewMapTilesLayer.class.st
@@ -276,10 +276,7 @@ GeoViewMapTilesLayer >> getGraphicPositionFromGeoPosition: aGeoPoint [
 	cartCoord := self mapProjection projLatLonToCart: absCoord.
 	
 	pos := currentGraphicProjection projCartToPixel: cartCoord.
-	
-	pos := pos + self viewInfos origin.
-	
-	^pos
+	^ pos
 ]
 
 { #category : #level }


### PR DESCRIPTION
Fix mouse zoom coordinates management (not global but local coordinates).